### PR TITLE
Use nginx 1.21.1, but without docker-nginx's full range of configuration options

### DIFF
--- a/docker-images/install-nginx-alpine.sh
+++ b/docker-images/install-nginx-alpine.sh
@@ -3,10 +3,10 @@
 # From official Nginx Docker image, as a script to re-use it, removing internal comments
 
 # Standard set up Nginx Alpine
-# https://github.com/nginxinc/docker-nginx/blob/594ce7a8bc26c85af88495ac94d5cd0096b306f7/mainline/alpine/Dockerfile
+# https://github.com/nginxinc/docker-nginx/blob/f958fbacada447737319e979db45a1da49123142/mainline/alpine/Dockerfile
 
-export NGINX_VERSION=1.17.10
-export NJS_VERSION=0.3.9
+export NGINX_VERSION=1.21.1
+export NJS_VERSION=0.6.1
 export PKG_RELEASE=1
 
 set -x \
@@ -19,7 +19,7 @@ set -x \
         nginx-module-njs=${NGINX_VERSION}.${NJS_VERSION}-r${PKG_RELEASE} \
     " \
     && case "$apkArch" in \
-        x86_64) \
+        x86_64|aarch64) \
             set -x \
             && KEY_SHA512="e7fa8303923d9b95db37a77ad46c68fd4755ff935d0a534d26eba83de193c76166c68bfe7f65471bf8881004ef4aa6df3e34689c305662750c0172fca5d8552a *stdin" \
             && apk add --no-cache --virtual .cert-deps \

--- a/docker-images/install-nginx-debian.sh
+++ b/docker-images/install-nginx-debian.sh
@@ -1,11 +1,11 @@
 #! /usr/bin/env bash
 
 # From official Nginx Docker image, as a script to re-use it, removing internal comments
-# Ref: https://github.com/nginxinc/docker-nginx/blob/594ce7a8bc26c85af88495ac94d5cd0096b306f7/mainline/buster/Dockerfile
+# Ref: https://github.com/nginxinc/docker-nginx/blob/f958fbacada447737319e979db45a1da49123142/mainline/debian/Dockerfile
 
 # Standard set up Nginx
-export NGINX_VERSION=1.17.10
-export NJS_VERSION=0.3.9
+export NGINX_VERSION=1.21.1
+export NJS_VERSION=0.6.1
 export PKG_RELEASE=1~buster
 
 set -x \
@@ -31,10 +31,10 @@ set -x \
         nginx-module-xslt=${NGINX_VERSION}-${PKG_RELEASE} \
         nginx-module-geoip=${NGINX_VERSION}-${PKG_RELEASE} \
         nginx-module-image-filter=${NGINX_VERSION}-${PKG_RELEASE} \
-        nginx-module-njs=${NGINX_VERSION}.${NJS_VERSION}-${PKG_RELEASE} \
+        nginx-module-njs=${NGINX_VERSION}+${NJS_VERSION}-${PKG_RELEASE} \
     " \
     && case "$dpkgArch" in \
-        amd64|i386) \
+        amd64|i386|arm64) \
             echo "deb https://nginx.org/packages/mainline/debian/ buster nginx" >> /etc/apt/sources.list.d/nginx.list \
             && apt-get update \
             ;; \
@@ -68,12 +68,13 @@ set -x \
     && apt-get install --no-install-recommends --no-install-suggests -y \
                         $nginxPackages \
                         gettext-base \
-    && apt-get remove --purge --auto-remove -y ca-certificates && rm -rf /var/lib/apt/lists/* /etc/apt/sources.list.d/nginx.list \
+                        curl \
+    && apt-get remove --purge --auto-remove -y && rm -rf /var/lib/apt/lists/* /etc/apt/sources.list.d/nginx.list \
     \
     && if [ -n "$tempDir" ]; then \
         apt-get purge -y --auto-remove \
         && rm -rf "$tempDir" /etc/apt/sources.list.d/temp.list; \
-    fi
+    fi \
 
 # forward request and error logs to docker log collector
 ln -sf /dev/stdout /var/log/nginx/access.log \


### PR DESCRIPTION
This avoids CVE-2021-23017, which was patched in 1.20.1.

Why didn't I include all configuration options from the nginx mainline
(1.21.1) docker image?

I tried, but docker-nginx has changed in a few additional ways. It now
* includes several entrypoint scripts which require certain variables to
be set,
* uses templates to generate these

So:
* the functionality here (may) need to be spread between this script and
a dockerfile to include them;
* all the environment variables required for these need to be settable
and documented;
* some of these scripts edit the nginx default.conf file, which this
repo doesn't use as a base so more work is required to make sure they
work properly on this repo's .conf

Branch https://github.com/SoloEnergy/uwsgi-nginx-docker/tree/update-nginx-to-1.21.1
will further look to implement the configuration for the current
standard nginx docker image on this one, namely:
* ipv6 listening by default
* templating in nginx.conf with flexible configuration
* auto-selection of worker process number (this container uses 1 by
default, as standard nginx does)